### PR TITLE
Nuxt module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,26 @@ yarn add @netsells/nuxt-meta-builder
 
 ## Usage
 
+Add the module to your nuxt config's `modules` array:
+
+```js
+module.exports = {
+    ...
+    modules: [
+        '@netsells/nuxt-meta-builder',
+    ],
+    ...
+};
+```
+
+You can then access the `$metaBuilder` function on the Vue instance:
+
 ```vue
 <script>
-    // Pull the plugin in
-    import Meta from '@netsells/nuxt-meta-builder';
-    
     export default {
         // Basic usage
         head() {
-            return (new Meta)
+            return this.$metaBuilder()
                 .setTitle('My page title')
                 .setDescription('The description for the current page')
                 .make();

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,0 +1,15 @@
+const path = require('path');
+
+/**
+ * Module registration function
+ */
+function metaBuilderModule() {
+  // Register plugin
+  this.addPlugin({
+    src: path.resolve(__dirname, 'plugin.js'),
+    fileName: 'meta-builder.js',
+  });
+}
+
+module.exports = metaBuilderModule;
+module.exports.meta = require('../package.json');

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,0 +1,4 @@
+import MetaBuilder from '@netsells/nuxt-meta-builder/dist/index';
+import Vue from 'vue';
+
+Vue.prototype.$metaBuilder = () => new MetaBuilder;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lib",
     "dist"
   ],
-  "main": "dist/index.js",
+  "main": "lib/module.js",
   "keywords": [
     "nuxt-meta-builder",
     "vue",


### PR DESCRIPTION
Updates the package to register as a nuxt module so that the MetaBuilder is available on the component instance instead of importing into the page manually.